### PR TITLE
Revise seo optimizations for truthful reporting

### DIFF
--- a/_pages/hire-me.md
+++ b/_pages/hire-me.md
@@ -28,8 +28,8 @@ For more detail on deliverables, visit the **[Services](/services/)** page.
 
 ## Proof that matters
 - **AWS Developer Associate (DVA‑C02)** — [Credly](https://www.credly.com/badges/f506ac5c-7a57-4edb-aafc-d8bbab0f511f/){:target="_blank"}
-- **Cloud Coach** — interactive AWS study tool used by thousands of exam takers.
-- Results: reduced AWS spend by 32% for a fintech, cut build time from 45 to 12 minutes for a SaaS platform, and shipped a greenfield Go payments API in under 8 weeks.
+- **Cloud Coach** — interactive AWS study tool I built to help engineers prepare for certifications.
+- Experience reducing AWS spend, accelerating CI/CD pipelines, and shipping Go backend services from scratch.
 - Case studies and background on the **[About](/about/)** page.
 
 ## Why remote collaboration works

--- a/_pages/remote-senior-go-developer.md
+++ b/_pages/remote-senior-go-developer.md
@@ -10,7 +10,7 @@ header:
 
 # Remote Senior Go & AWS Developer for Hire
 
-Need a remote senior software engineer who can own Go services, modernize AWS, and mentor your team without a months-long hiring process? As an **AWS Certified Developer (DVA-C02)** with a decade of Go experience, I help distributed startups and scaleups ship faster while keeping cloud costs predictable. Think of this as hiring both a principal Go engineer and a pragmatic cloud architect—without adding full-time headcount immediately.
+Need a remote senior software engineer who can own Go services, modernize AWS, and mentor your team without a months-long hiring process? As an **AWS Certified Developer (DVA-C02)** with hands-on Go and cloud experience, I help distributed startups and scaleups ship faster while keeping cloud costs predictable. Think of this as hiring both a principal Go engineer and a pragmatic cloud architect—without adding full-time headcount immediately.
 
 ## Who hires me
 - **Product-led SaaS teams** that need a principal-level Go engineer to stabilize and extend APIs and cloud infrastructure.
@@ -24,12 +24,12 @@ Need a remote senior software engineer who can own Go services, modernize AWS, a
 - **Fractional leadership** — 1–2 days per week covering architecture reviews, planning, hiring support, and AWS governance.
 - **Mentorship pods** — small-group coaching for Go, AWS, or platform engineers leveling up.
 
-## Sample results
-- Launched a payment microservice in Go that now processes 2M+ requests/day with &lt;120 ms p95 latency.
-- Cut AWS spend by 32% by right-sizing ECS workloads, adding autoscaling policies, and optimizing storage tiers.
-- Reduced deploy time from 45 to 12 minutes by reworking CI/CD, release trains, and IaC pipelines using Terraform + GitHub Actions.
-- Delivered multi-Region failover readiness for an IoT platform using AWS Lambda, SQS, EventBridge, and DynamoDB.
-- Helped three engineers earn AWS SAA/DVA certifications via targeted study plans and drills.
+## What I typically deliver
+- High-throughput Go microservices built for production traffic and low latency.
+- AWS cost optimization through right-sizing, autoscaling, and storage tier reviews.
+- Faster CI/CD pipelines using Terraform, GitHub Actions, and streamlined release processes.
+- Multi-region and failover architectures leveraging Lambda, SQS, EventBridge, and DynamoDB.
+- AWS certification coaching (SAA/DVA) with structured study plans and hands-on drills.
 
 ## Timezone & collaboration
 - Based in Taipei (UTC+8) with consistent overlap to Pacific, Eastern, and Central European hours.


### PR DESCRIPTION
<!-- This is an enhancement or feature. -->

## Summary

Replaced specific, fabricated numbers and claims with more general, truthful descriptions of capabilities and experience across `_pages/hire-me.md` and `_pages/remote-senior-go-developer.md`.

## Context

This PR addresses feedback from the previous "Optimize seo for more software engineering jobs" PR, where specific numerical claims were added that were not accurate. The changes aim to make the content truthful while still being descriptive.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c23d143-1fcb-44fb-9b50-66b18c650b64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5c23d143-1fcb-44fb-9b50-66b18c650b64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Generalizes marketing claims on `hire-me.md` and `remote-senior-go-developer.md`, removing specific numbers and reframing results as typical deliverables.
> 
> - **Content updates**:
>   - `/_pages/hire-me.md`:
>     - Replaces specific Cloud Coach/results claims with generalized statements about the tool and experience.
>   - `/_pages/remote-senior-go-developer.md`:
>     - Softens intro experience phrasing.
>     - Renames `Sample results` to `What I typically deliver` and replaces quantified results with generalized deliverables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3116a598b828ad9ed4375e7aca3b2168b38b1775. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->