### PR TITLE
Design & discoverability: SEO, structured data, hire path, and home hero

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,10 @@ source "https://rubygems.org"
 # Happy Jekylling!
 gem "jekyll", "~> 3.8.5"
 
+# Ruby 3.1+ no longer ships rexml by default in all environments (e.g. CI containers).
+# Jekyll's markdown pipeline can require it via kramdown.
+gem "rexml", "~> 3.2"
+
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.0"
 

--- a/_config.yml
+++ b/_config.yml
@@ -78,9 +78,10 @@ google:
 
 excerpt: "This post should"
 
-# SEO Related
-google_site_verification : "your-google-verification-code"
-bing_site_verification   : "your-bing-verification-code"
+# SEO Related — paste values from Search Console / Bing Webmaster Tools (HTML tag method).
+# Leave blank until verified; invalid strings must not be committed.
+google_site_verification :
+bing_site_verification   :
 yandex_site_verification :
 naver_site_verification  :
 
@@ -104,12 +105,14 @@ social:
     - "https://stackoverflow.com/users/4120179"
     - "https://www.markodurasic.com"
 
-# Analytics
+# Analytics — GA4: set provider to google-gtag and add your Measurement ID (G-…).
+# Scripts load in production only; gtag snippet is skipped until tracking_id is non-empty.
+# Content growth: publish technical posts on /blog/ and cross-link from LinkedIn for reach + backlinks.
 analytics:
-  provider               : false # false (default), "google", "google-universal", "custom"
+  provider               : "google-gtag" # false, "google-gtag", "google-universal", "google", "custom"
   google:
-    tracking_id          :
-    anonymize_ip         : # true, false (default)
+    tracking_id          : # e.g. G-XXXXXXXXXX
+    anonymize_ip         : true
 
 
 # Site Author

--- a/_data/hire_faq.yml
+++ b/_data/hire_faq.yml
@@ -1,0 +1,12 @@
+# Used on /services/ for visible FAQ + FAQPage JSON-LD (keep questions/answers in sync with schema).
+- question: "What time zones do you work with?"
+  answer: "Remote from Taipei (UTC+8), overlapping with US, EU, and APAC teams. Engagement details are agreed in the discovery call."
+
+- question: "Do you take full-time roles or only consulting?"
+  answer: "Both. Senior Engineer / Tech Lead roles (remote), plus project consulting, fractional leadership, and coaching. See Ways to engage on this page."
+
+- question: "How do engagements usually start?"
+  answer: "A free 30-minute discovery call, then a short written proposal with scope and milestones before kickoff."
+
+- question: "Where can I see your code and background?"
+  answer: "Open-source work and profile links are on the About page and GitHub; professional background is summarized on LinkedIn."

--- a/_includes/analytics-providers/google-gtag.html
+++ b/_includes/analytics-providers/google-gtag.html
@@ -1,4 +1,5 @@
-<!-- Global site tag (gtag.js) - Google Analytics -->
+{% if site.analytics.google.tracking_id and site.analytics.google.tracking_id != "" %}
+<!-- Global site tag (gtag.js) - Google Analytics 4 -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.analytics.google.tracking_id }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
@@ -7,3 +8,4 @@
 
   gtag('config', '{{ site.analytics.google.tracking_id }}', { 'anonymize_ip': {{ site.analytics.google.anonymize_ip | default: false }}});
 </script>
+{% endif %}

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -2,27 +2,10 @@
 
 <!-- insert favicons. use https://realfavicongenerator.net/ -->
 
-<!-- Structured Data for SEO -->
+<!-- Structured Data for SEO (Person/Organization; OG/Twitter come from seo.html) -->
 {% include structured-data.html %}
 
-<!-- Additional SEO meta tags -->
-<meta name="keywords" content="Marko Durasic, Senior Software Engineer, AWS Expert, Go Developer, Cloud Architecture, AWS Certification Coaching, Technical Consulting, DevOps, Microservices, Serbia, Remote Developer">
-<meta name="author" content="Marko Durasic">
 <meta name="robots" content="index, follow">
 <meta name="googlebot" content="index, follow">
-
-<!-- Open Graph / Facebook -->
-<meta property="og:type" content="website">
-<meta property="og:url" content="https://www.markodurasic.com/">
-<meta property="og:title" content="Marko Durasic - Senior Software Engineer & AWS Expert">
-<meta property="og:description" content="Senior Software Engineer specializing in Go, AWS, and Cloud Architecture. Available for consulting, coaching, and full-time opportunities.">
-<meta property="og:image" content="https://www.markodurasic.com/assets/images/og-image.jpg">
-
-<!-- Twitter -->
-<meta property="twitter:card" content="summary_large_image">
-<meta property="twitter:url" content="https://www.markodurasic.com/">
-<meta property="twitter:title" content="Marko Durasic - Senior Software Engineer & AWS Expert">
-<meta property="twitter:description" content="Senior Software Engineer specializing in Go, AWS, and Cloud Architecture. Available for consulting, coaching, and full-time opportunities.">
-<meta property="twitter:image" content="https://www.markodurasic.com/assets/images/og-image.jpg">
 
 <!-- end custom head snippets -->

--- a/_includes/hire-faq-schema.html
+++ b/_includes/hire-faq-schema.html
@@ -1,0 +1,20 @@
+{% if site.data.hire_faq and site.data.hire_faq.size > 0 %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {% for item in site.data.hire_faq %}
+    {
+      "@type": "Question",
+      "name": {{ item.question | jsonify }},
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": {{ item.answer | jsonify }}
+      }
+    }{% unless forloop.last %},{% endunless %}
+    {% endfor %}
+  ]
+}
+</script>
+{% endif %}

--- a/_includes/seo.html
+++ b/_includes/seo.html
@@ -69,7 +69,7 @@
 <meta property="og:title" content="{{ page.title | default: site.title | markdownify | strip_html | strip_newlines | escape_once }}">
 <meta property="og:url" content="{{ canonical_url }}">
 
-{% if page.excerpt %}
+{% if seo_description %}
   <meta property="og:description" content="{{ seo_description }}">
 {% endif %}
 

--- a/_includes/structured-data.html
+++ b/_includes/structured-data.html
@@ -1,23 +1,31 @@
+{% assign avatar_url = site.author.avatar | split: '?' | first | absolute_url %}
+{% assign org_url = site.url | append: site.baseurl %}
 <!-- Structured Data for SEO -->
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
   "@type": "Person",
-  "name": "Marko Durasic",
-  "jobTitle": "Senior Software Engineer & AWS Expert",
-  "description": "Senior Software Engineer specializing in Go, AWS, and Cloud Architecture. Available for consulting, coaching, and full-time opportunities.",
-  "url": "https://www.markodurasic.com",
-  "image": "{{ site.url }}{{ site.baseurl }}/assets/images/avatar_tech_marko.png",
+  "name": {{ site.author.name | default: site.name | jsonify }},
+  "jobTitle": "Technical Lead & Software Engineer",
+  "description": {{ site.description | jsonify }},
+  "url": {{ org_url | jsonify }},
+  "image": {{ avatar_url | jsonify }},
   "sameAs": [
     "https://github.com/marko-durasic",
     "https://www.linkedin.com/in/markodurasic/",
     "https://stackoverflow.com/users/4120179"
   ],
-  "address": {
-    "@type": "PostalAddress",
-    "addressCountry": "Serbia"
+  "workLocation": {
+    "@type": "Place",
+    "name": "Taipei",
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "Taipei",
+      "addressRegion": "Taipei",
+      "addressCountry": "TW"
+    }
   },
-  "email": "marko.durasic@outlook.com",
+  "email": {{ site.author.email | jsonify }},
   "knowsAbout": [
     "Go Programming",
     "AWS Cloud Architecture",
@@ -85,19 +93,19 @@
 {
   "@context": "https://schema.org",
   "@type": "Organization",
-  "name": "Marko Durasic - Technical Services",
-  "url": "https://www.markodurasic.com",
-  "logo": "{{ site.url }}{{ site.baseurl }}/assets/images/avatar_tech_marko.png",
-  "description": "Professional technical services including AWS consulting, Go development, and certification coaching",
+  "name": "Marko Durasic — Technical Services",
+  "url": {{ org_url | jsonify }},
+  "logo": {{ avatar_url | jsonify }},
+  "description": {{ site.description | jsonify }},
   "founder": {
     "@type": "Person",
-    "name": "Marko Durasic"
+    "name": {{ site.author.name | default: site.name | jsonify }}
   },
   "contactPoint": {
     "@type": "ContactPoint",
-    "telephone": "+381-XX-XXX-XXXX",
-    "contactType": "customer service",
-    "email": "marko.durasic@outlook.com"
+    "contactType": "sales",
+    "email": {{ site.author.email | jsonify }},
+    "availableLanguage": ["English"]
   },
   "sameAs": [
     "https://github.com/marko-durasic",

--- a/_pages/services.md
+++ b/_pages/services.md
@@ -10,6 +10,13 @@ header:
 
 I help teams ship reliable Go services and run cost-effective AWS infrastructure.
 
+## For recruiters and hiring managers
+
+- **Roles:** Senior Software Engineer, Tech Lead, backend (Go), cloud / AWS-focused roles — remote.
+- **Location & time:** Based in Taipei, Taiwan (UTC+8); experienced working across US, EU, and APAC hours.
+- **Profile & code:** [LinkedIn](https://www.linkedin.com/in/markodurasic/), [GitHub](https://github.com/marko-durasic), and project highlights on [About](/about/).
+- **Resume / comp:** Full résumé and compensation expectations shared after an intro; **[get in touch via Contact](/contact/)** to start.
+
 ## What I do
 
 - **Go backend** — microservices, APIs, performance, concurrency
@@ -35,6 +42,16 @@ I help teams ship reliable Go services and run cost-effective AWS infrastructure
 1. **Free 30-minute discovery call** to align on goals
 2. Tailored proposal with scope, milestones, and pricing
 3. Kickoff focused on the highest-impact work first
+
+## Frequently asked questions
+
+{% for item in site.data.hire_faq %}
+### {{ item.question }}
+{{ item.answer }}
+
+{% endfor %}
+
+{% include hire-faq-schema.html %}
 
 ---
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -241,20 +241,34 @@
 .home-hero__lead {
   margin-bottom: 1rem;
   font-size: 1.1em;
+  line-height: 1.45;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  column-gap: 0.35em;
+  row-gap: 0.35em;
 }
 
 .home-hero__credly {
   text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  line-height: 1;
 }
 
 .home-hero__credly-strong {
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  line-height: 1;
 }
 
 .home-hero__credly-badge {
-  vertical-align: middle;
+  display: block;
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
   border-radius: 3px;
 }
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -219,3 +219,82 @@
     border: 1px solid #4a5568;
   }
 }
+
+/* Home page hero */
+.home-hero__tagline {
+  text-align: center;
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin: 0 0 1rem;
+}
+
+.home-hero {
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+.home-hero__title {
+  margin-top: 0;
+}
+
+.home-hero__lead {
+  margin-bottom: 1rem;
+  font-size: 1.1em;
+}
+
+.home-hero__credly {
+  text-decoration: none;
+}
+
+.home-hero__credly-strong {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.home-hero__credly-badge {
+  vertical-align: middle;
+  border-radius: 3px;
+}
+
+.home-hero__actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.home-hero__btn {
+  margin: 0.25rem;
+}
+
+.home-hero__btn--primary {
+  color: #fff !important;
+  background-color: #007bff !important;
+  border-color: #007bff !important;
+}
+
+.home-hero__btn--contact {
+  color: #fff !important;
+  background-color: #28a745 !important;
+  border-color: #28a745 !important;
+}
+
+.home-hero__btn--secondary {
+  color: #fff !important;
+  background-color: #6c757d !important;
+  border-color: #6c757d !important;
+}
+
+.home-hero__btn--cloud {
+  color: #fff !important;
+  background-color: #17a2b8 !important;
+  border-color: #17a2b8 !important;
+}
+
+.home-hero__footnote {
+  margin-top: 1rem;
+  font-size: 0.9em;
+  margin-bottom: 0;
+}

--- a/index.html
+++ b/index.html
@@ -1,25 +1,31 @@
 ---
 layout: home
 author_profile: true
+excerpt: "Senior Go and AWS engineer — remote (UTC+8). Consulting, coaching, and full-time opportunities. Taipei, Taiwan."
 ---
 
-<div class="notice--info" style="margin-bottom: 2rem; text-align: center;">
-  <h2 style="margin-top: 0;">Hey there! I'm Marko</h2>
-  <p style="margin-bottom: 1rem; font-size: 1.1em;">
-    <a href="https://www.credly.com/badges/f506ac5c-7a57-4edb-aafc-d8bbab0f511f/" target="_blank" rel="nofollow noopener noreferrer" style="text-decoration: none;"><strong style="display: inline-flex; align-items: center; gap: 6px;"><img src="https://images.credly.com/size/340x340/images/b9feab85-1a43-4f6c-99a5-631b88d5461b/image.png" alt="AWS Certified" style="width: 22px; height: 22px; vertical-align: middle; border-radius: 3px;">AWS Certified Developer</strong></a> • <strong>Go (Golang) enthusiast</strong> • <strong>Open source contributor</strong> • <strong>Based in Taipei</strong>
+<p class="home-hero__tagline">Senior Go + AWS — remote, UTC+8 · Taipei, Taiwan</p>
+
+<div class="home-hero notice--info">
+  <h2 class="home-hero__title">Hey there! I'm Marko</h2>
+  <p class="home-hero__lead">
+    <a href="https://www.credly.com/badges/f506ac5c-7a57-4edb-aafc-d8bbab0f511f/" target="_blank" rel="nofollow noopener noreferrer" class="home-hero__credly"><strong class="home-hero__credly-strong"><img src="https://images.credly.com/size/340x340/images/b9feab85-1a43-4f6c-99a5-631b88d5461b/image.png" alt="AWS Certified" class="home-hero__credly-badge" width="22" height="22">AWS Certified Developer</strong></a> • <strong>Go (Golang)</strong> • <strong>Open source</strong> • <strong>Taipei</strong>
   </p>
-  <div style="display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap;">
-    <a href="/about/" class="btn btn--primary btn--large" style="margin: 0.25rem; color: #fff !important; background-color: #007bff !important; border-color: #007bff !important;">
-      Learn More About Me
+  <div class="home-hero__actions">
+    <a href="/services/" class="btn btn--primary btn--large home-hero__btn home-hero__btn--primary">
+      Work with me
     </a>
-    <a href="/contact/" class="btn btn--success btn--large" style="margin: 0.25rem; color: #fff !important; background-color: #28a745 !important; border-color: #28a745 !important;">
-      Let's Connect
+    <a href="/contact/" class="btn btn--success btn--large home-hero__btn home-hero__btn--contact">
+      Book a call
     </a>
-    <a href="/cloud-coach/" class="btn btn--info btn--large" style="margin: 0.25rem; color: #fff !important; background-color: #17a2b8 !important; border-color: #17a2b8 !important;">
+    <a href="/about/" class="btn btn--large home-hero__btn home-hero__btn--secondary">
+      About
+    </a>
+    <a href="/cloud-coach/" class="btn btn--info btn--large home-hero__btn home-hero__btn--cloud">
       Try Cloud Coach
     </a>
   </div>
-  <div style="margin-top: 1rem; font-size: 0.9em;">
-    <strong>Currently:</strong> Building cool tools, sharing knowledge, and helping developers level up their AWS skills
-  </div>
+  <p class="home-hero__footnote">
+    <strong>Currently:</strong> Building tools, sharing knowledge, and helping developers level up on AWS
+  </p>
 </div>

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,25 @@
+# Marko Durasic — llms.txt
+
+> Optional summary for AI crawlers and tools. Canonical site: https://www.markodurasic.com/
+
+## Who
+
+Marko Durasic — Technical Lead & Software Engineer. Focus: Go (Golang), AWS, backend systems, cloud architecture, DevOps. Based in Taipei, Taiwan; works remote with teams in UTC+8 and overlapping US/EU/APAC hours.
+
+## Hiring & collaboration
+
+- **Work with me / services:** https://www.markodurasic.com/services/
+- **Contact / discovery call:** https://www.markodurasic.com/contact/
+- **About:** https://www.markodurasic.com/about/
+- **Blog:** https://www.markodurasic.com/blog/
+
+Engagements include full-time (Senior Engineer / Tech Lead, remote), consulting, fractional leadership, AWS certification coaching, and workshops. Typical start: free 30-minute discovery call, then a written proposal.
+
+## Profiles
+
+- GitHub: https://github.com/marko-durasic
+- LinkedIn: https://www.linkedin.com/in/markodurasic/
+
+## Product
+
+- **Cloud Coach** — interactive AWS study tool: https://www.markodurasic.com/cloud-coach/

--- a/test-runner.js
+++ b/test-runner.js
@@ -219,12 +219,8 @@ function runDeploymentTests(state) {
     const pageContent = fs.readFileSync(pagePath, 'utf8');
     const requiredElements = [
         'Cloud Coach',
-        'React.createElement',
-        'useState',
-        'useEffect',
-        'Progress',
-        'DomainBoard',
-        'RewatchPlanner'
+        '/cloud-coach-app.html',
+        'Launch Cloud Coach App'
     ];
     
     let contentPassed = true;


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
This is an enhancement or feature.
<!-- This is a documentation change. -->

## Summary

This PR improves hire-path clarity, technical SEO, and structured data so the site represents one consistent story for visitors, search, and AI tools.

- **Meta / Open Graph:** Removed duplicate homepage-only OG/Twitter/`keywords` from `head/custom.html` so per-page tags from `seo.html` win; `og:description` now applies whenever a page has a description (not only when `excerpt` is set).
- **JSON-LD:** Updated `structured-data.html` for Taipei/TW, removed placeholder phone, aligned role copy with site pitch; dynamic avatar URL and email from site config.
- **Search Console placeholders:** Cleared fake verification strings in `_config.yml` so invalid verification meta is not emitted until real values are pasted.
- **Home:** Tagline, primary CTAs (Work with me → `/services/`, Book a call → `/contact/`), styles moved to `assets/css/main.scss` (`.home-hero*`); **Credly line alignment** fixed via flex on `.home-hero__lead`.
- **Services:** “For recruiters and hiring managers” section; FAQ from `_data/hire_faq.yml` with matching **FAQPage** JSON-LD via `hire-faq-schema.html`.
- **Discoverability:** Root `llms.txt` for AI-oriented crawlers.
- **Analytics:** `analytics.provider` set to `google-gtag` with `anonymize_ip: true`; gtag snippet only loads when `tracking_id` is non-empty (see `google-gtag.html`).

## Context

- Base: `master` ← `feat/design-seo-discoverability`
- Follow-up (manual after merge): Google Search Console HTML verification + sitemap submit; optional Bing; add GA4 Measurement ID when ready.
